### PR TITLE
Id's in octane are in fact strings and not numbers.  

### DIFF
--- a/lib/models/reference.js
+++ b/lib/models/reference.js
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 'use strict'
 
@@ -21,13 +21,12 @@
 var assert = require('assert')
 
 /**
-* @class
-*
-* @param {Number} id - the referenced entity id
-* @param {String} type - the referenced entity type
-*/
-var Reference = function reference (id, type) {
-  assert(typeof id === 'number')
+ * @class
+ *
+ * @param {String} id - the referenced entity id
+ * @param {String} type - the referenced entity type
+ */
+var Reference = function reference(id, type) {
   assert(typeof type === 'string')
   this.id = id
   this.type = type
@@ -47,9 +46,6 @@ Reference.parse = function (val) {
 
   if (typeof val === 'object' && 'id' in val && 'type' in val) {
     var id = val.id
-    if (typeof id === 'string') {
-      id = parseInt(id, 10)
-    }
     return new Reference(id, val.type)
   }
 


### PR DESCRIPTION
Remove the forced conversion to number and assertion.
This is critical as many id's in Octane are not number like and then the conversion fails and you get a Nan