### PR TITLE
add parameter `routesConfig` to the constructor of Octane client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ $ npm i @microfocus/hpe-alm-octane-js-rest-sdk
 
 ## Example
 
+> Please note that for the first time use, you need to do [Update client API](#update-client-api) first.
+
 ```javascript
 var Octane = require('@microfocus/hpe-alm-octane-js-rest-sdk')
 
@@ -20,7 +22,8 @@ var octane = new Octane({
   host: <HOST>,
   port: <PORT>,
   shared_space_id: <SHARED_SPACE_ID>,
-  workspace_id: <WORKSPACE_ID>
+  workspace_id: <WORKSPACE_ID>,
+  routesConfig: <ROUTES_CONFIG_FILE_PATH> | <ROUTES_CONFIG_JSON_OBJECT>
 })
 
 octane.authenticate({
@@ -122,7 +125,7 @@ octane.defects.getAll({query: query}, function (err, defect) {
 
 ...
 
-// query statement: "name EQ ^test*^" 
+// query statement: "name EQ ^test*^"
 var query = Query.field('name').equal('test*')
 
 // query statement: "user_tags EQ {id EQ 1001}"
@@ -155,7 +158,7 @@ var query = Query.field('id').inComparison([1,2,3])
 var query = query1.and(query2)
 
 // for null use either Query.NULL for non-reference fields or Query.NULL_REFERENCE for references (Query.NONE still exists for backwards-compatibility
-// and is the same as Query.NULL_REFERENCE) 
+// and is the same as Query.NULL_REFERENCE)
 var query1 = Query.field('string_field').equal(Query.NULL)
 var query2 = Query.field('reference_field').equal(Query.NULL_REFERENCE)
 ```
@@ -177,7 +180,7 @@ octane.attachments.create(attachment, function (err, attachment) {
 ...
 ```
 
-The attachment has both entity data and binary data. 
+The attachment has both entity data and binary data.
 To get the attachment's entity data, call `attachments.get()`; to get its binary data, call `attachments.download()`.
 
 ```javascript
@@ -197,7 +200,7 @@ octane.attachments.download({id: attachmentID}, function (err, data) {
 The MF ALM Octane REST API is fully metadata-driven. When the Octane REST API is updated, you can update the client API from the metadata.
 
 Create a configuration file (eg `octane.json`) file for updating client API. It defines the Octane server's configuration and user credentials.  Note that by default the tech preview API is *not* enabled.  To enable it
-(especially when using attachments) use the `tech_preview_API` key as demonstrated below 
+(especially when using attachments) use the `tech_preview_API` key as demonstrated below
 
 ```bash
 $ cat > octane.json << EOH
@@ -224,6 +227,8 @@ $ node scripts/generate_default_routes.js /path/to/octane.json
 ```
 
 > The client API is defined in `routes/default.json` file. When you run this script to update the client API, you actually update the `routes/default.json` file.
+
+> You can copy this file to any other places (a place under the control of VCS for example), and pass the file's absolute path to the client constructor to use it, see [Example](#example).
 
 > The `routes/meta.json` file defines the minimal client API. It can't be changed or deleted.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,7 @@ var DEFAULT_ROUTES_FILE = '../routes/default.json'
 * @param {Number} config.shared_space_id - Octane shared space id
 * @param {Number} config.workspace_id - Octane workspace id
 * @param {String} [config.proxy] - if set, using proxy to connect to Octane
+* @param {String|Object} [config.routesConfig] - if set, using the specified path as API definition, or use the JSON object directly
 */
 var Octane = function octane (config) {
   config = config || {}
@@ -55,7 +56,13 @@ var Octane = function octane (config) {
 
   this.config = config
 
-  if (fs.existsSync(path.join(__dirname, DEFAULT_ROUTES_FILE))) {
+  if (config.routesConfig && typeof config.routesConfig === 'object') {
+    this.routes = config.routesConfig
+  } else if (config.routesConfig && path.isAbsolute(config.routesConfig) && fs.existsSync(config.routesConfig)) {
+    this.routes = JSON.parse(
+      fs.readFileSync(config.routesConfig)
+    )
+  } else if (fs.existsSync(path.join(__dirname, DEFAULT_ROUTES_FILE))) {
     this.routes = JSON.parse(
       fs.readFileSync(path.join(__dirname, DEFAULT_ROUTES_FILE), 'utf8')
     )


### PR DESCRIPTION
issue #17 . User can put the `default.json` to any other places and pass in the absolute path to the constructor, or pass in a JSON object.