### PR TITLE
removes handling of env proxy vars as its already done by the request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,12 +109,7 @@ Octane.prototype.authenticate = function authenticate (options, callback) {
     baseUrl: baseUrl
   }
 
-  var proxy = this.config.proxy ||
-    process.env.HTTPS_PROXY ||
-    process.env.https_proxy ||
-    process.env.HTTP_PROXY ||
-    process.env.http_proxy
-  if (proxy) {
+  if (this.config.proxy) {
     opt.proxy = proxy
   }
 


### PR DESCRIPTION
for reference: 

https://github.com/request/request/blob/536f0e76b249e4545c3ba2ac75e643146ebf3824/lib/getProxyFromURI.js#L40

request module states:
```
  // Decide the proper request proxy to use based on the request URI object and the
  // environmental variables (NO_PROXY, HTTP_PROXY, etc.)
  // respect NO_PROXY environment variables (see: http://lynx.isc.org/current/breakout/lynx_help/keystrokes/environments.html)
```