### PR TITLE
Proxy set if explicitly given. The requestor handles the evn variables.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,13 +115,8 @@ Octane.prototype.authenticate = function authenticate (options, callback) {
     baseUrl: baseUrl
   }
 
-  var proxy = this.config.proxy ||
-    process.env.HTTPS_PROXY ||
-    process.env.https_proxy ||
-    process.env.HTTP_PROXY ||
-    process.env.http_proxy
-  if (proxy) {
-    opt.proxy = proxy
+  if (this.config.proxy) {
+    opt.proxy = this.config.proxy
   }
 
   debug('with options %j', opt)


### PR DESCRIPTION
The request library handles the HTTP(S)_PROXY variables as well as the NO_PROXY variable. We should set the proxy only if explicitly given as a parameter because otherwise all the requests will contain that proxy whether it should actually be used or not. Tested when HTTPS_PROXY exists and octane both needs and doesn`t need a proxy.  Also tested the case when a different proxy is needed to reach Octane  (not the one specified in HTTPS_PROXY) and when no HTTPS_PROXY is used and the proxy is explicitly given.   
Explicitly giving the proxy overrides the any proxy that is(or not) set in the env variables.