### PR TITLE
Fix expired authentication

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ var DEFAULT_ROUTES_FILE = '../routes/default.json'
  * @param {Number} config.workspace_id - Octane workspace id
  * @param {String} [config.proxy] - if set, using proxy to connect to Octane
  * @param {String|Object} [config.routesConfig] - if set, using the specified path as API definition, or use the JSON object directly
+ * @param {OctaneCredentials} [config.octaneCredentials] - credentials needed to access octane
  */
 var Octane = function octane (config) {
   config = config || {}
@@ -72,38 +73,12 @@ var Octane = function octane (config) {
     )
   }
 
+  if (this.config.octaneCredentials) {
+    this.octaneCredentials = this.config.octaneCredentials
+    delete this.config.octaneCredentials
+  }
+
   this.setupRoutes()
-}
-
-/**
- * @callback Octane~authenticateCallback
- * @param {Object} - error that occurred
- */
-
-/**
- * Login to Ocatne. It's required for futher requests.
- *
- * @param {Object} [octaneCredentials] - Object containing the user credential or API key
- * @param {String} [octaneCredentials].username - username
- * @param {String} [octaneCredentials].password - password
- * @param {String} [octaneCredentials].client_id - API client id
- * @param {String} [octaneCredentials].client_secret - API client secret
- * @param {Octane~authenticateCallback} callback - callback that handles error and authenticated operations
- */
-Octane.prototype.authenticate = function authenticate (octaneCredentials, callback) {
-  if (callback === undefined && typeof octaneCredentials === 'function') {
-    callback = octaneCredentials
-    octaneCredentials = undefined
-  }
-  if (octaneCredentials) {
-    this.octaneCredentials = octaneCredentials
-  } else {
-    if (!this.octaneCredentials) {
-      const error = new Error('No authentication credentials given')
-      callback(error)
-    }
-  }
-  debug('authenticate %j', octaneCredentials)
 
   const host = this.config.host ||
     this.constants.host
@@ -116,12 +91,15 @@ Octane.prototype.authenticate = function authenticate (octaneCredentials, callba
     ? '/' + this.config.pathPrefix.replace(/(^[/]+|[/]+$)/g, '')
     : ''
 
-  let baseUrl = protocol + '://' + host + ':' + port + pathPrefix
-
+  this.baseUrl = protocol + '://' + host + ':' + port + pathPrefix
+  this.baseApiUrl = this.baseUrl + '/api/shared_spaces/' + this.config.shared_space_id + '/workspaces/' + this.config.workspace_id
   const opt = {
     jar: true,
     json: true,
-    baseUrl: baseUrl
+    baseUrl: this.baseApiUrl
+  }
+  if (this.config.tech_preview_API) {
+    opt.headers = { HPECLIENTTYPE: 'HPE_REST_API_TECH_PREVIEW' }
   }
 
   const proxy = this.config.proxy ||
@@ -135,7 +113,30 @@ Octane.prototype.authenticate = function authenticate (octaneCredentials, callba
 
   debug('with octaneCredentials %j', opt)
 
-  let requestor = request.defaults(opt)
+  this.requestor = request.defaults(opt)
+}
+
+/**
+ * Login to Octane.
+ * @param {OctaneCredentials|Octane~authenticateCallback} [octaneCredentials] - Credentials needed to access octane.
+ *        If no credentials are given, the last given credentials will be used.
+ *        If no credentials were ever given, the callback will be called with an error.
+ * @param {Octane~authenticateCallback} callback - Callback that handles error and authenticated operations
+ */
+Octane.prototype.authenticate = function authenticate (octaneCredentials, callback) {
+  if (callback === undefined && typeof octaneCredentials === 'function') {
+    callback = octaneCredentials
+    octaneCredentials = undefined
+  }
+  if (octaneCredentials) {
+    this.octaneCredentials = octaneCredentials
+  } else {
+    if (!this.octaneCredentials) {
+      const error = new Error('No authentication credentials given')
+      return callback(error)
+    }
+  }
+  debug('authenticate %j', octaneCredentials)
 
   const body = {}
   if (this.octaneCredentials.username && this.octaneCredentials.password) {
@@ -146,9 +147,10 @@ Octane.prototype.authenticate = function authenticate (octaneCredentials, callba
     body.client_secret = this.octaneCredentials.client_secret
   }
 
-  requestor.post({
-    uri: '/authentication/sign_in',
-    body: body
+  this.requestor.post({
+    url: this.baseUrl + '/authentication/sign_in',
+    body: body,
+    baseUrl: '' // set base url to nothing such that the url is not interpreted as an uri
   }, (err, response, body) => {
     if (err) {
       debug('authentication failed %j', err)
@@ -161,19 +163,6 @@ Octane.prototype.authenticate = function authenticate (octaneCredentials, callba
       return callback(err)
     }
 
-    baseUrl = baseUrl +
-      '/api/shared_spaces/' + this.config.shared_space_id +
-      '/workspaces/' + this.config.workspace_id
-
-    requestor = requestor.defaults({
-      baseUrl: baseUrl
-    })
-
-    if (this.config.tech_preview_API) {
-      requestor = requestor.defaults({ headers: { HPECLIENTTYPE: 'HPE_REST_API_TECH_PREVIEW' } })
-    }
-
-    this.requestor = requestor
     callback()
   })
 }
@@ -532,3 +521,21 @@ Octane.prototype.sendError = function sendError (err, msg, block, callback) {
 }
 
 module.exports = Octane
+
+/**
+ * Octane API access credentials
+ * @typedef {Object} OctaneApiCredentials
+ * @property {String} client_id - API client id
+ * @property {String} client_secret - API client secret
+ *
+ * Octane User credentials
+ * @typedef {Object} OctaneUserCredentials
+ * @property {String} username - username
+ * @property {String} password - password
+ *
+ * Octane User credentials
+ * @typedef {OctaneUserCredentials|OctaneApiCredentials} OctaneCredentials
+ *
+ * @callback Octane~authenticateCallback
+ * @param {Object} - error that occurred
+ */

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ var DEFAULT_ROUTES_FILE = '../routes/default.json'
  * @param {Number} config.workspace_id - Octane workspace id
  * @param {String} [config.proxy] - if set, using proxy to connect to Octane
  * @param {String|Object} [config.routesConfig] - if set, using the specified path as API definition, or use the JSON object directly
-*/
+ */
 var Octane = function octane (config) {
   config = config || {}
   if (!config.host || !config.shared_space_id || !config.workspace_id) {
@@ -83,39 +83,48 @@ var Octane = function octane (config) {
 /**
  * Login to Ocatne. It's required for futher requests.
  *
- * @param {Object} options - Object containing the user credential or API key
- * @param {String} options.username - username
- * @param {String} options.password - password
- * @param {String} options.client_id - API client id
- * @param {String} options.client_secret - API client secret
+ * @param {Object} [octaneCredentials] - Object containing the user credential or API key
+ * @param {String} [octaneCredentials].username - username
+ * @param {String} [octaneCredentials].password - password
+ * @param {String} [octaneCredentials].client_id - API client id
+ * @param {String} [octaneCredentials].client_secret - API client secret
  * @param {Octane~authenticateCallback} callback - callback that handles error and authenticated operations
  */
-Octane.prototype.authenticate = function authenticate (options, callback) {
-  var self = this
-  options = options || {}
+Octane.prototype.authenticate = function authenticate (octaneCredentials, callback) {
+  if (callback === undefined && typeof octaneCredentials === 'function') {
+    callback = octaneCredentials
+    octaneCredentials = undefined
+  }
+  if (octaneCredentials) {
+    this.octaneCredentials = octaneCredentials
+  } else {
+    if (!this.octaneCredentials) {
+      const error = new Error('No authentication credentials given')
+      callback(error)
+    }
+  }
+  debug('authenticate %j', octaneCredentials)
 
-  debug('authenticate %j', options)
-
-  var host = this.config.host ||
+  const host = this.config.host ||
     this.constants.host
-  var protocol = this.config.protocol ||
+  const protocol = this.config.protocol ||
     this.constants.protocol ||
     'http'
-  var port = this.config.port ||
+  const port = this.config.port ||
     (protocol === 'https' ? 443 : 80)
-  var pathPrefix = this.config.pathPrefix
+  const pathPrefix = this.config.pathPrefix
     ? '/' + this.config.pathPrefix.replace(/(^[/]+|[/]+$)/g, '')
     : ''
 
-  var baseUrl = protocol + '://' + host + ':' + port + pathPrefix
+  let baseUrl = protocol + '://' + host + ':' + port + pathPrefix
 
-  var opt = {
+  const opt = {
     jar: true,
     json: true,
     baseUrl: baseUrl
   }
 
-  var proxy = this.config.proxy ||
+  const proxy = this.config.proxy ||
     process.env.HTTPS_PROXY ||
     process.env.https_proxy ||
     process.env.HTTP_PROXY ||
@@ -124,24 +133,23 @@ Octane.prototype.authenticate = function authenticate (options, callback) {
     opt.proxy = proxy
   }
 
-  debug('with options %j', opt)
+  debug('with octaneCredentials %j', opt)
 
-  var requestor = request.defaults(opt)
+  let requestor = request.defaults(opt)
 
-  var body = {}
-  // var body = {}
-  if (options.username && options.password) {
-    body.user = options.username
-    body.password = options.password
-  } else if (options.client_id && options.client_secret) {
-    body.client_id = options.client_id
-    body.client_secret = options.client_secret
+  const body = {}
+  if (this.octaneCredentials.username && this.octaneCredentials.password) {
+    body.user = this.octaneCredentials.username
+    body.password = this.octaneCredentials.password
+  } else if (this.octaneCredentials.client_id && this.octaneCredentials.client_secret) {
+    body.client_id = this.octaneCredentials.client_id
+    body.client_secret = this.octaneCredentials.client_secret
   }
 
   requestor.post({
     uri: '/authentication/sign_in',
     body: body
-  }, function (err, response, body) {
+  }, (err, response, body) => {
     if (err) {
       debug('authentication failed %j', err)
       return callback(err)
@@ -154,18 +162,18 @@ Octane.prototype.authenticate = function authenticate (options, callback) {
     }
 
     baseUrl = baseUrl +
-      '/api/shared_spaces/' + self.config.shared_space_id +
-      '/workspaces/' + self.config.workspace_id
+      '/api/shared_spaces/' + this.config.shared_space_id +
+      '/workspaces/' + this.config.workspace_id
 
     requestor = requestor.defaults({
       baseUrl: baseUrl
     })
 
-    if (self.config.tech_preview_API) {
+    if (this.config.tech_preview_API) {
       requestor = requestor.defaults({ headers: { HPECLIENTTYPE: 'HPE_REST_API_TECH_PREVIEW' } })
     }
 
-    self.requestor = requestor
+    this.requestor = requestor
     callback()
   })
 }
@@ -390,19 +398,33 @@ Octane.prototype.sanitizeParam = function verifyParam (paramName, value, definit
   return value
 }
 
-Octane.prototype.handler = function handler (msg, block, callback) {
-  var self = this
-
-  this.httpSend(msg, block, function (err, response, body) {
+Octane.prototype.handler = function handler (msg, block, callback, retryIfUnauthorized = true) {
+  this.httpSend(msg, block, (err, response, body) => {
     if (err) {
-      return self.sendError(err, msg, block, callback)
+      return this.sendError(err, msg, block, callback)
     }
 
     debug('status %d', response.statusCode)
 
+    if (response.statusCode === 401) {
+      if (retryIfUnauthorized) {
+        debug('Trying to reauthenticate')
+        return this.authenticate((err) => {
+          if (err) {
+            callback(err)
+          } else {
+            this.handler(msg, block, callback, false)
+          }
+        })
+      } else {
+        err = new error.HttpError(body, response.statusCode, response.headers)
+        return this.sendError(err, msg, block, callback)
+      }
+    }
+
     if (response.statusCode >= 400) {
       err = new error.HttpError(body, response.statusCode, response.headers)
-      return self.sendError(err, msg, block, callback)
+      return this.sendError(err, msg, block, callback)
     }
 
     var ret = body


### PR DESCRIPTION
Requests now try to re-authenticate once if the response from the server is 401 Unauthorized. Since one octane object is already bounded to one shared space (actually to one works space),  credentials are stored in the octane object and are used when trying to re-authenticate. 
The requestor object is created when the octane object is created to prevent "requestoris not a function" exception when making an octane call before authenticating. This error should actually be an Unauthorized response. A side effect of this is that if credentials are given when creating an octane object, an explicit authentication is no longer actually required. The failed initial request (with 401) will try to re-authenticate with the given credentials which may result in the request working when it would have previously thrown an exception. 