### PR TITLE
Filter out on-behalf-of header for auth request

### DIFF
--- a/lib/root/requestHandler.ts
+++ b/lib/root/requestHandler.ts
@@ -224,7 +224,7 @@ class RequestHandler {
 
         logger.debug('Signing in...');
         return await this.sendRequestWithCookies(authOptions.url, async (headersWithCookie) => {
-            let filteredCookies =
+            const filteredHeadersWithCookie =
                 headersWithCookie && this.hasHeader(headersWithCookie, 'on-behalf-of')
                 ? this.filterOutHeaders(headersWithCookie, ['on-behalf-of'])
                 : headersWithCookie;
@@ -232,7 +232,7 @@ class RequestHandler {
                 authOptions.url,
                 authOptions.body,
                 {
-                    headers: filteredCookies
+                    headers: filteredHeadersWithCookie
                 }
             );
             logger.debug('Signed in.');


### PR DESCRIPTION
Filtered out the on-behalf-of header because the authentication is made by the API key and not by the user on which behalf the request is done