### PR TITLE
security issue #2870101 - Upgrade brace-expansion version

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ $ npm test test/query.js
 
 ## What's new :newspaper: <a name="whats-new"></a>
 * 25.4.0
-  * Upgraded `brace-expansion` version 
+  * Upgraded `brace-expansion` version to fix a vulnerable dependency
 * 25.3.0
   * Removed ON-BEHALF-OF header from `authenticate()` method
   

--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ $ npm test test/query.js
 ```
 
 ## What's new :newspaper: <a name="whats-new"></a>
+* 25.4.0
+  * Upgraded `brace-expansion` version 
 * 25.3.0
   * Removed ON-BEHALF-OF header from `authenticate()` method
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/request": "^2.48.8",
         "@types/tough-cookie": "^4.0.5",
         "axios-mock-adapter": "2.1.0",
+        "brace-expansion": "^2.0.2",
         "mocha": "^10.4.0",
         "mocha-jenkins-reporter": "0.4.8",
         "typescript": "^5.8.3"
@@ -433,9 +434,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/request": "^2.48.8",
     "@types/tough-cookie": "^4.0.5",
     "axios-mock-adapter": "2.1.0",
+    "brace-expansion": "^2.0.2",
     "mocha": "^10.4.0",
     "mocha-jenkins-reporter": "0.4.8",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfocus/alm-octane-js-rest-sdk",
-  "version": "25.3.0",
+  "version": "25.4.0",
   "description": "NodeJS wrapper for the OpenText Core Software Delivery Platform API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Normally `brace-expansion` is a transitive dependency having the following dependency-tree:

`-- mocha@10.8.2`
  `-- minimatch@5.1.6`
    `-- brace-expansion@2.0.1`

The reason I installed it as a standalone dependency is that `mocha 10.8.2` is the last version that is supported by `mocha-jenkins-reporter`, which in turn is updated to the last version released (`0.4.8`), so there is no way of upgrading `mocha` so it pulls a newer version of `brace-expansion`.