### PR TITLE
defect #2962113: align my work entities between octane and ide plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ $ npm test test/query.js
 ```
 
 ## What's new :newspaper: <a name="whats-new"></a>
+* 26.1.0
+  Standardize the structure and behavior of model items and process entities across VS Code plugins
 * 25.4.0
   * Upgraded `brace-expansion` version to fix a vulnerable dependency
 * 25.3.0

--- a/lib/root/octane.ts
+++ b/lib/root/octane.ts
@@ -96,10 +96,12 @@ class Octane {
     manualTests: string;
     metaphases: string;
     milestones: string;
+    modelItems: string;
     phases: string;
     pipelineNodes: string;
     pipelineRuns: string;
     previousRuns: string;
+    processItems: string;
     programs: string;
     releases: string;
     requirementDocuments: string;
@@ -113,6 +115,8 @@ class Octane {
     sprints: string;
     stories: string;
     suiteRun: string;
+    suiteRunSchedulers: string;
+    suiteRunSchedulerRuns: string;
     tasks: string;
     taxonomyCategoryNodes: string;
     taxonomyItemNodes: string;
@@ -151,10 +155,12 @@ class Octane {
     manualTests: 'manualTests',
     metaphases: 'metaphases',
     milestones: 'milestones',
+    modelItems: 'model_items',
     phases: 'phases',
     pipelineNodes: 'pipeline_nodes',
     pipelineRuns: 'pipeline_runs',
     previousRuns: 'previous_runs',
+    processItems: 'processes',
     programs: 'programs',
     releases: 'releases',
     requirementDocuments: 'requirement_documents',
@@ -168,6 +174,8 @@ class Octane {
     sprints: 'sprints',
     stories: 'stories',
     suiteRun: 'suite_run',
+    suiteRunSchedulers: 'suite_run_schedulers',
+    suiteRunSchedulerRuns: 'suite_run_scheduler_runs',
     tasks: 'tasks',
     taxonomyCategoryNodes: 'taxonomy_category_nodes',
     taxonomyItemNodes: 'taxonomy_item_nodes',

--- a/lib/root/octane.ts
+++ b/lib/root/octane.ts
@@ -101,7 +101,7 @@ class Octane {
     pipelineNodes: string;
     pipelineRuns: string;
     previousRuns: string;
-    processItems: string;
+    processes: string;
     programs: string;
     releases: string;
     requirementDocuments: string;
@@ -160,7 +160,7 @@ class Octane {
     pipelineNodes: 'pipeline_nodes',
     pipelineRuns: 'pipeline_runs',
     previousRuns: 'previous_runs',
-    processItems: 'processes',
+    processes: 'processes',
     programs: 'programs',
     releases: 'releases',
     requirementDocuments: 'requirement_documents',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microfocus/alm-octane-js-rest-sdk",
-  "version": "25.3.0",
+  "version": "25.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microfocus/alm-octane-js-rest-sdk",
-      "version": "25.3.0",
+      "version": "25.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "0.5.0",
@@ -20,7 +20,7 @@
         "@types/http-errors": "^2.0.4",
         "@types/jest": "^29.5.12",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^22.15.3",
+        "@types/node": "^22.19.1",
         "@types/pluralize": "^0.0.33",
         "@types/request": "^2.48.8",
         "@types/tough-cookie": "^4.0.5",
@@ -243,9 +243,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfocus/alm-octane-js-rest-sdk",
-  "version": "25.4.0",
+  "version": "25.4.1",
   "description": "NodeJS wrapper for the OpenText Core Software Delivery Platform API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
     "@types/http-errors": "^2.0.4",
     "@types/jest": "^29.5.12",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^22.15.3",
+    "@types/node": "^22.19.1",
     "@types/pluralize": "^0.0.33",
     "@types/request": "^2.48.8",
     "@types/tough-cookie": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfocus/alm-octane-js-rest-sdk",
-  "version": "25.4.1",
+  "version": "26.1.0",
   "description": "NodeJS wrapper for the OpenText Core Software Delivery Platform API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2962113

Problem: Some entities from My Work (Model Based Test module) in Octane are not visible in the IntelliJ plugin.

Solution: I added the missing entities to the plugin so that they match the ones in Octane.